### PR TITLE
[update] divide `app.py` into `Cogs` && use `commands.bot`

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,9 +2,8 @@ import os
 import discord
 from discord.ext import commands
 
-DISCORD_API_KEY = os.environ.get("DISCORD_API_KEY")
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
+from config import DISCORD_API_KEY, DISCORD_SERVER_KEY
+
 guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 bot = commands.Bot(command_prefix='/', intents=discord.Intents.all())
@@ -14,6 +13,7 @@ COGS = [
     "modules.route",
     "modules.event",
     "modules.speak",
+    "modules.aichat",
     "modules.ese_chinese"
 ]
 
@@ -23,7 +23,7 @@ async def on_ready():
     print('------')
     for cogs in COGS:
         await bot.load_extension(cogs)
-        print("Loaded: {cogs}")
+        print(f"Loaded: {cogs}")
 
     await bot.tree.sync(guild=guild)
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+import os
+
+DISCORD_API_KEY = os.environ.get("DISCORD_API_KEY")
+DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")

--- a/modules/aichat.py
+++ b/modules/aichat.py
@@ -3,15 +3,15 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
-guild = discord.Object(id=DISCORD_SERVER_KEY)
-
 import openai
+
+from config import DISCORD_SERVER_KEY, OPENAI_API_KEY
+
+guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 class AIChat:
     def __init__(self):
-        openai.api_key = os.environ.get('OPENAI_API_KEY')
+        openai.api_key = OPENAI_API_KEY
 
     def response(self, prompt: str):
         response = openai.Completion.create(

--- a/modules/ese_chinese.py
+++ b/modules/ese_chinese.py
@@ -3,12 +3,12 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
-guild = discord.Object(id=DISCORD_SERVER_KEY)
-
 import MeCab
 import sys
+
+from config import DISCORD_SERVER_KEY
+
+guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 def generate_embed(prompt: str, user: discord.User) -> discord.Embed:
     embed = discord.Embed(

--- a/modules/event.py
+++ b/modules/event.py
@@ -3,8 +3,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
+from config import DISCORD_SERVER_KEY
+
 guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 from datetime import datetime

--- a/modules/hello.py
+++ b/modules/hello.py
@@ -3,8 +3,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
+from config import DISCORD_SERVER_KEY
+
 guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 class Hello(commands.Cog):

--- a/modules/help.py
+++ b/modules/help.py
@@ -3,8 +3,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
+from config import DISCORD_SERVER_KEY
+
 guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 class Help(commands.Cog):

--- a/modules/route.py
+++ b/modules/route.py
@@ -9,8 +9,8 @@ from selenium.webdriver.common.by import By
 import datetime
 from typing import Tuple
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
+from config import DISCORD_SERVER_KEY
+
 guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 def get_nearest_station(user: str) -> Tuple[str, str, str, int]:

--- a/modules/speak.py
+++ b/modules/speak.py
@@ -3,15 +3,15 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-# サーバコマンドを設定するギルド
-DISCORD_SERVER_KEY = os.environ.get("DISCORD_SERVER_KEY")
-guild = discord.Object(id=DISCORD_SERVER_KEY)
-
 import requests
 import json
 import time
 from datetime import datetime
 from collections import deque
+
+from config import DISCORD_SERVER_KEY
+
+guild = discord.Object(id=DISCORD_SERVER_KEY)
 
 def synthesis(text, filename, speaker=1, max_retry=20):
     query_payload = {"text": text, "speaker": speaker}


### PR DESCRIPTION
## issue

- Null

## 変更の概要

- `app.py` にまとめていた `send_hoge` コマンドたちを `module` 直下にそれぞれ分割

## 変更の理由（なぜこの変更をするのか）

- メンテナンス性の向上
- `global` 変数を使わないようにする
  - 今まで `global` で持っていた `queue, voice_client...` といった変数を（適当に）クラス変数として定義し直した

## その他

### 既知の問題

- 当該変更に伴い，今まで行っていた `on_message` での `None` チェックを排除
  - 当該変更に伴いメッセージ投稿時に `AttributeError` が発生している
  - 今後修正予定