### PR TITLE
[update] use ChatGPT API (instead of GPT-3) in /chat command, add `/tundere` command

### DIFF
--- a/modules/aichat.py
+++ b/modules/aichat.py
@@ -60,12 +60,12 @@ class Chat(commands.Cog):
             )
         await ctx.followup.send(answer)
 
-    @app_commands.command(name="tundere", description="ツンデレ美少女とおしゃべりします．")
+    @app_commands.command(name="tsundere", description="ツンデレ美少女とおしゃべりします．")
     @app_commands.guilds(guild)
     @discord.app_commands.describe(
         prompt="ツンデレ美少女に話しかける内容です．"
     )
-    async def send_tundere(self, ctx: discord.Interaction, prompt: str):
+    async def send_tsundere(self, ctx: discord.Interaction, prompt: str):
         await ctx.response.defer()
         await ctx.followup.send(embed=generate_embed(prompt, ctx.user))
         async with ctx.channel.typing():


### PR DESCRIPTION
## Issue

- None

## 変更の概要

- `/chat` コマンドが利用する API を，GPT-3 から ChatGPT (`gpt-3.5-turbo`) に変更
- 新たにツンデレ美少女応対用のコマンド `/tundere` を追加

## 変更の理由（なぜこの変更をするのか）

- `/chat` コマンドの回答精度向上を狙うため．

## その他
