### PR TITLE
[hotfix] Fixed environment variable configuration for Github CI/CD

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,3 +22,4 @@ jobs:
           DISCORD_API_KEY: ${{ secrets.DISCORD_API_KEY }}
           DISCORD_SERVER_KEY: ${{ secrets.DISCORD_SERVER_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SPEAK_CHAT_DEFAULT_CHANNEL_ID: ${{ secrets.SPEAK_CHAT_DEFAULT_CHANNEL_ID }}


### PR DESCRIPTION
## issue

- None

## 変更の概要

- Github CI/CD に対する環境変数設定不備を修正
    - `.github/workflows/workflow.yml` に環境変数 `SPEAK_CHAT_DEFAULT_CHANNEL_ID` を適用し忘れていた

## 変更の理由（なぜこの変更をするのか）

- 忘れてたから
    - このまま運用すると，裸で `/speak-chat` コマンドを実行すると Bot 全体の動作が止まってしまう問題が発生する

## その他

- 再発防止に努めます．
