### PR TITLE
[fix] multiple definitions of `\speak-dict` commands && bugfix for `\route` command

### DIFF
--- a/modules/route.py
+++ b/modules/route.py
@@ -33,7 +33,7 @@ def get_route_url(from_station: str, to_station: str, via_station: str, search_m
     dt = datetime.datetime.now() + datetime.timedelta(minutes=deltatime)
     year, month, day, hour, minute = dt.year, dt.month, dt.day, dt.hour, dt.minute
 
-    route_url = f"https://transit.yahoo.co.jp/search/print?from={from_station}&flatlon=&to={to_station}&via={via_station}&s={search_method}&y={year}&m={str(month).zfill(2)}&d={str(day).zfill(2)}&hh={hour}&m1={minute//10}&m2={minute%10}"
+    route_url = f"https://transit.yahoo.co.jp/search/print?from={from_station}&flatlon=&to={to_station}&via={via_station}&s={search_method}&y={year}&m={str(month).zfill(2)}&d={str(day).zfill(2)}&hh={str(hour).zfill(2)}&m1={minute//10}&m2={minute%10}"
     return route_url
 
 def save_route_screenshot(target_url: str, file_path: str, range_id: str="srline") -> None:

--- a/modules/speak.py
+++ b/modules/speak.py
@@ -274,7 +274,7 @@ class Speak(commands.Cog):
         app_commands.Choice(name="白上虎太郎", value=12),
         app_commands.Choice(name="冥鳴ひまり", value=14),
     ])
-    async def send_speak_dict(self, ctx: discord.Interaction, speaker: int):
+    async def send_speak_set(self, ctx: discord.Interaction, speaker: int):
         await ctx.response.defer(ephemeral=True)
         await regist_voicevox_speaker(ctx.guild_id, ctx.user.id, speaker)
         await ctx.followup.send(f"登録しました．")


### PR DESCRIPTION
- [fix] the route to home is displayed even if `/route` command is executed.
- [fix] Unable to execute `/speak-dict` command due to duplicated function names in `speak.py`
- [fix] the walking time to the nearest station to the workplace was reflected in all route searches

## issue

- None

## 変更の概要

- 関数名の重複により，`/speak-dict` コマンドが機能していなかった問題を修正
- `/route` コマンドを実行しても `/home` コマンドの結果が返ってしまう問題を修正
- `/home` コマンドを実行時に考慮するはずの駅徒歩時間が，`/route` コマンドを実行した際にも考慮されていた問題を修正
  - `deltatime` として個人の駅徒歩時間を `/route-register` コマンドで修正できるように変更

## 変更の理由（なぜこの変更をするのか）

- bugfix

## その他

- 変数名がクソガバなので変更案がほしいです
